### PR TITLE
add auto placeholder functionalities

### DIFF
--- a/js/alcasthqmain.js
+++ b/js/alcasthqmain.js
@@ -1,0 +1,58 @@
+var autoplaceBodyAds = function () {
+    var lbsList = ['nn_lb3', 'nn_lb4', 'nn_lb5', 'nn_lb6'];
+    var createNewInsert = function (id, domElement) {
+        var parentDiv = domElement.parentNode;
+        var div = document.createElement('div');
+        div.setAttribute('id', id);
+        div.setAttribute('style', 'text-align:center;');
+        parentDiv.insertBefore(div, domElement);
+    };
+
+    var getPostContentDiv = function () {
+        var postContent = document.getElementById('content');
+        if (postContent) {
+            return postContent.querySelector('.post-content');
+        }
+        return null;
+    }
+
+    var getPlacementSequence = function (noOfH3) {
+        if (noOfH3) {
+            if (noOfH3 > 10) {
+                return 3;
+            }
+            if (noOfH3 > 8 && noOfH3 < 10) {
+                return 2;
+            }
+        }
+        return 1;
+    }
+
+    var startInserting = function(h3s) {
+        var noOfH3 = h3s.length;
+        if (noOfH3 > 2) {
+            var h3PlacementIndex = 1;
+            var placementSequence = getPlacementSequence(noOfH3);
+            for (var h3LoopIndex = 0; h3LoopIndex < noOfH3; h3LoopIndex++) {
+                if (lbsList[h3LoopIndex] && h3s[h3PlacementIndex]) {
+                    createNewInsert(lbsList[h3LoopIndex], h3s[h3PlacementIndex]);
+                }
+                h3PlacementIndex += placementSequence;
+            }
+        }
+    }
+
+    var postContent = getPostContentDiv();
+    if (postContent) {
+        var h3s = postContent.querySelectorAll("h3");
+        if (h3s) {
+            startInserting(h3s);
+        }
+    }
+};
+
+jQuery(document).ready(function () {
+    if (autoplaceBodyAdsVars && !autoplaceBodyAdsVars.isHomePage) {
+        autoplaceBodyAds();
+    }
+});

--- a/networkn-ad-helper.php
+++ b/networkn-ad-helper.php
@@ -138,6 +138,14 @@ class NetworkN_AdHelper
         if ($this->atlasEnabled()) {
             $custom_css_path = sprintf('%scss/%s/custom.min.css', plugin_dir_url(__FILE__), $this->domain);
             wp_enqueue_style('nn-custom', $custom_css_path);
+
+            wp_enqueue_script('alcast_main_js',
+                plugins_url('/js/alcasthqmain.js', __FILE__),
+                [], false, true);
+
+            wp_localize_script("alcast_main_js", "autoplaceBodyAdsVars", [
+                'isHomePage' => (is_home() || is_front_page())
+            ]);
         }
     }
 


### PR DESCRIPTION
This task will be difficult to test but on live because of the nature in which the code was written

The code was written specifically for the alcasthq site and made many references to it throughout the plugin. For example -

public function atlasEnabled()
{
return $this->domain === 'alcasthq.com';
}

To get around this for your local computer testing the developer had to make a few adjustments to get it to work. And this involves the following tricks (Bearing in mind that we wont have a local version and database of this site):

comment out is_preview() on my local version of the wordpress installation

change the hardcoded domain referenced to the one we are using locally

copy html from the alcast site into the DOM of the local wordpress installation to test

 

The following shows us inserting what would be an advert into the DOM every 3 H3s apart as the page is very long. Here is a video of this being tested on our local development machine

![image](https://user-images.githubusercontent.com/84023099/180448454-205200e3-ae7a-471e-be7c-5f90a654ea22.png)

Notes on testing.

This code targets the H3s on the alcast pages apart from the Home page.

If the page is very long, it inserts a leaderboard ad every 3 H3s apart

A shorter page will see advertising appearing every two H3s apart or even every 1 h3s apart
